### PR TITLE
Release v0.3.1

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,4 @@
+consolidate-commits = true
+sign-commit = true
+sign-tag = true
+tag-name = "v{{version}}"


### PR DESCRIPTION
This releases `v0.3.1` so users get the fix from #2.